### PR TITLE
Add link for contact email

### DIFF
--- a/gettingStarted.html
+++ b/gettingStarted.html
@@ -316,7 +316,7 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
 							<h2 style="color: white !important">Contact Us</h2>
 							<dl class="alt">
 								<dt>Email</dt>
-								<dd><a href="#">contact@bounties.network</a></dd>
+								<dd><a href="mailto:contact@bounties.network">contact@bounties.network</a></dd>
 							</dl>
 							<ul class="icons">
 								<li><a href="https://twitter.com/ethBounties" class="icon fa-twitter alt alt2"><span class="label">Twitter</span></a></li>


### PR DESCRIPTION
Adds `mailto:` target to the contact email link on the getting started page.